### PR TITLE
Retry verifying ntp pool connectivity

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,4 +39,5 @@ include_recipe 'ntp::default'
 
 execute 'verify ntp pool connectivity' do
   command '! /usr/bin/ntpq -p | grep "\.INIT\."'
+  retries 5
 end


### PR DESCRIPTION
Retrying 5 times because it takes roughly 3-4 seconds
for the ntpservice itself to come up and about 1 second per
ntp server to initialize so in total about 6-7 seconds.

the default retry delay is 2 seconds therefore 2 * 5 is
roughly 10 seconds of leeway for the service to fully recover
from a restart that chef itself might have caused (or just a
simple service start b/c it installed the ntp package on first
converge)

@see https://docs.chef.io/resource_common.html for retry documentation