### PR TITLE
Add "ntp_master" tag only if the node is eligible for ntp servers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,5 +9,5 @@ LineLength:
   Max: 120
 
 # Lining up the attributes of some methods is advantageous for readability
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,5 +9,9 @@ default['ntp_cluster']['public_servers'] = [
   '3.pool.ntp.org'
 ]
 
+default['ntp_cluster']['verify']['retries'] = 12
+default['ntp_cluster']['verify']['retry_delay'] = 5
+
 set['ntp']['servers'] = node['ntp_cluster']['public_servers']
 set['ntp']['conf_restart_immediate'] = true
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,6 @@ include_recipe 'ntp::default'
 
 execute 'verify ntp pool connectivity' do
   command '! /usr/bin/ntpq -p | grep "\.INIT\."'
-  retries 12
-  retry_delay 5
+  retries node['ntp_cluster']['verify']['retries']
+  retry_delay node['ntp_cluster']['verify']['retry_delay']
 end

--- a/recipes/discover.rb
+++ b/recipes/discover.rb
@@ -58,7 +58,7 @@ if masters.length > 1
     node.normal['tags'] = node['tags'].reject { |t| t == node['ntp_cluster']['master_tag'] }.uniq
 
     if node['tags'].include? 'ntp_master'
-      fail '  > You are overriding me! Please check your overrides for tags attribute'
+      raise '  > You are overriding me! Please check your overrides for tags attribute'
     end
   end
 
@@ -71,7 +71,7 @@ elsif masters.length == 1
 else
   tags = node['tags'] || []
   if node.role?(node['ntp_cluster']['server_role'])
-    node.normal['tags'] = tags.push(node['ntp_cluster']['master_tag']).uniq 
+    node.normal['tags'] = tags.push(node['ntp_cluster']['master_tag']).uniq
     node.set['ntp_cluster']['master'] = node['fqdn']
   end
 end

--- a/recipes/discover.rb
+++ b/recipes/discover.rb
@@ -68,16 +68,18 @@ if masters.length > 1
 elsif masters.length == 1
   log 'Master is ' + masters.first
   node.set['ntp_cluster']['master'] = masters.first
-else
+
+elsif node.role?(node['ntp_cluster']['server_role'])
   tags = node['tags'] || []
-  if node.role?(node['ntp_cluster']['server_role'])
-    node.normal['tags'] = tags.push(node['ntp_cluster']['master_tag']).uniq
-    node.set['ntp_cluster']['master'] = node['fqdn']
-  end
+  node.normal['tags'] = tags.push(node['ntp_cluster']['master_tag']).uniq
+  node.set['ntp_cluster']['master'] = node['fqdn']
+
+else
+  Chef::Log.warn 'No servers detected.'
 end
 
 node.set['ntp_cluster']['standbys'] = standbys.compact
 
-Chef::Log.info " > Tags: #{node['tags'].inspect}"
+Chef::Log.warn " > Tags: #{node['tags'].inspect}"
 Chef::Log.info " > Master Server: #{node['ntp_cluster']['master'].inspect}"
 Chef::Log.info " > Standby Servers: #{node['ntp_cluster']['standbys'].inspect}"

--- a/recipes/discover.rb
+++ b/recipes/discover.rb
@@ -70,9 +70,10 @@ elsif masters.length == 1
   node.set['ntp_cluster']['master'] = masters.first
 else
   tags = node['tags'] || []
-  node.normal['tags'] = tags.push(node['ntp_cluster']['master_tag']).uniq
-
-  node.set['ntp_cluster']['master'] = node['fqdn']
+  if node.role?(node['ntp_cluster']['server_role'])
+    node.normal['tags'] = tags.push(node['ntp_cluster']['master_tag']).uniq 
+    node.set['ntp_cluster']['master'] = node['fqdn']
+  end
 end
 
 node.set['ntp_cluster']['standbys'] = standbys.compact

--- a/recipes/discover.rb
+++ b/recipes/discover.rb
@@ -68,12 +68,10 @@ if masters.length > 1
 elsif masters.length == 1
   log 'Master is ' + masters.first
   node.set['ntp_cluster']['master'] = masters.first
-
 elsif node.role?(node['ntp_cluster']['server_role'])
   tags = node['tags'] || []
   node.normal['tags'] = tags.push(node['ntp_cluster']['master_tag']).uniq
   node.set['ntp_cluster']['master'] = node['fqdn']
-
 else
   Chef::Log.warn 'No servers detected.'
 end

--- a/recipes/discover.rb
+++ b/recipes/discover.rb
@@ -80,6 +80,6 @@ end
 
 node.set['ntp_cluster']['standbys'] = standbys.compact
 
-Chef::Log.warn " > Tags: #{node['tags'].inspect}"
+Chef::Log.info " > Tags: #{node['tags'].inspect}"
 Chef::Log.info " > Master Server: #{node['ntp_cluster']['master'].inspect}"
 Chef::Log.info " > Standby Servers: #{node['ntp_cluster']['standbys'].inspect}"


### PR DESCRIPTION
When client is built before any ntp server exists in the chef environment, that node is tagged as 'ntp_master' while it's not eligible for the server role.
wrapped tagging section with if statement to check the node's role.

also, sometimes initial sync takes more than 60 seconds so I've made the retry options flexible so that users can change them in their wrapper cookbook.

finally, I have also fixed rubocop's obsolete configuration and 2 offenses.